### PR TITLE
External .props/.target file support and two synchronization fixes

### DIFF
--- a/NuGetNativeMSBuildTasks/CoApp.NuGetNativeMSBuildTasks.csproj
+++ b/NuGetNativeMSBuildTasks/CoApp.NuGetNativeMSBuildTasks.csproj
@@ -52,6 +52,7 @@
     <Compile Include="AsyncProcess.cs" />
     <Compile Include="CheckRuntimeLibrary.cs" />
     <Compile Include="MsBuildTaskBase.cs" />
+    <Compile Include="SemaphoreTasks.cs" />
     <Compile Include="NuGetPackageOverlay.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />
     <Compile Include="$(SolutionDir)\common\AssemblyStrongName.cs" />

--- a/NuGetNativeMSBuildTasks/SemaphoreTasks.cs
+++ b/NuGetNativeMSBuildTasks/SemaphoreTasks.cs
@@ -1,0 +1,101 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+
+namespace CoApp.NuGetNativeMSBuildTasks {
+    using System.Runtime.InteropServices;
+    using Microsoft.Build.Framework;
+
+    internal static class SemaphoreFunctions {
+
+        // NOT using the .Net Semaphore implementation (System.Threading.Semaphore) because it will automatically release the semaphore on object disposal.
+
+        [DllImport("kernel32.dll", SetLastError = true)]
+        public static extern IntPtr CreateSemaphore(IntPtr lpSemaphoreAttributes, int initialCount, int maximumCount, string name);
+
+        [DllImport("kernel32.dll")]
+        public static extern bool ReleaseSemaphore(IntPtr hSemaphore, int lReleaseCount, IntPtr lpPreviousCount);
+
+        [DllImport("kernel32.dll", SetLastError = true)]
+        public static extern UInt32 WaitForSingleObject(IntPtr hHandle, UInt32 dwMilliseconds);
+
+        [DllImport("kernel32.dll", SetLastError = true)]
+        [return: MarshalAs(UnmanagedType.Bool)]
+        public static extern bool CloseHandle(IntPtr hObject);
+
+        public const UInt32 INFINITE = 0xFFFFFFFF;
+        public const UInt32 WAIT_OBJECT_0 = 0x00000000;
+        public const UInt32 ERROR_ALREADY_EXISTS = 183;
+
+        public static IntPtr ParseHandle(string value) {
+            if (IntPtr.Size == 4)
+                return new IntPtr(int.Parse(value));
+            if (IntPtr.Size == 8)
+                return new IntPtr(long.Parse(value));
+            throw new Exception("What kind of pointer is this?!");
+        }
+    }
+
+    public class AcquireSemaphore : MsBuildTaskBase {
+
+        private IntPtr _handle;
+
+        [Required]
+        public string Name {get; set;}
+
+        [Output]
+        public string Handle {
+            get {
+                return _handle.ToString();
+            }
+            set {
+                _handle = SemaphoreFunctions.ParseHandle(value);
+            }
+        }
+
+        public override bool Execute() {
+            _handle = SemaphoreFunctions.CreateSemaphore(IntPtr.Zero, 0, 1, Name);
+            if (_handle == IntPtr.Zero)
+                throw new Exception("CreateSemaphore failed with error #" + Marshal.GetLastWin32Error());
+
+            bool createdNew = (Marshal.GetLastWin32Error() != SemaphoreFunctions.ERROR_ALREADY_EXISTS);
+
+            if (!createdNew) {
+                uint retval = SemaphoreFunctions.WaitForSingleObject(_handle, SemaphoreFunctions.INFINITE);
+                if (retval != SemaphoreFunctions.WAIT_OBJECT_0) {
+                    SemaphoreFunctions.CloseHandle(_handle);
+                    throw new Exception("WaitForSingleObject failed with error #" + Marshal.GetLastWin32Error());
+                }
+            }
+
+            return true;
+        }
+    }
+
+    public class ReleaseSemaphore : MsBuildTaskBase {
+
+        private IntPtr _handle;
+
+        [Required]
+        public string Handle {
+            get {
+                return _handle.ToString();
+            }
+            set {
+                _handle = SemaphoreFunctions.ParseHandle(value);
+            }
+        }
+
+        public override bool Execute() {
+            try {
+                bool retval = SemaphoreFunctions.ReleaseSemaphore(_handle, 1, IntPtr.Zero);
+                if (!retval)
+                    throw new Exception("ReleaseSemaphore failed with error #" + Marshal.GetLastWin32Error());
+                return true;
+            } finally {
+                SemaphoreFunctions.CloseHandle(_handle);
+            }
+        }
+    }
+}

--- a/clrplus/Scripting.MsBuild/Packaging/NugetPackage.cs
+++ b/clrplus/Scripting.MsBuild/Packaging/NugetPackage.cs
@@ -47,7 +47,7 @@ namespace ClrPlus.Scripting.MsBuild.Packaging {
         internal static string NuGetNativeExtensionPathValue = @"$(MSBuildThisFileDirectory)\private";
         internal static string NuGetNativeExtensionPathCondition = @"'$({0})' == '' OR '$({1})' =='' OR $({1}) < {2}".format(NuGetNativeExtensionPath, NuGetNativeExtensionVersion, NuGetNativeExtensionVersionValue);
 
-        internal static string[] MSBuildExtensionTasks = { "NuGetPackageOverlay", "CheckRuntimeLibrary", "StringContains" };
+        internal static string[] MSBuildExtensionTasks = { "NuGetPackageOverlay", "CheckRuntimeLibrary", "StringContains", "AcquireSemaphore", "ReleaseSemaphore" };
 
         internal static string NuGetPackageOverlayTaskAssembly = @"$({0})\coapp.NuGetNativeMSBuildTasks.dll".format(NuGetNativeExtensionPath);
 
@@ -111,6 +111,17 @@ namespace ClrPlus.Scripting.MsBuild.Packaging {
            
             Props = new Lazy<ProjectPlus>(() => new ProjectPlus(this, "{0}.props".format(_pkgName)));
             Targets = new Lazy<ProjectPlus>(() => new ProjectPlus(this, "{0}.targets".format(_pkgName)));
+
+            // ***************** VisionMap Custom Modification ***********************************
+            // Acquire semaphore because executing any tasks in the AfterBuild step of the package.
+            // This prevents errors when multiple consumers of the package try to copy package
+            // redistributables to the same destination. (see release in the Save method)
+            if (packageRole == PackageRole.@default) { // not needed in the overlay package
+                var semaphore = Targets.Value.LookupTarget("AfterBuild").AddTask("AcquireSemaphore");
+                semaphore.SetParameter("Name", "Sync_AfterBuild_" + _pkgName);
+                semaphore.AddOutputProperty("Handle", "SemaphoreHandle");
+            }
+            // ***********************************************************************************
 
             _nuSpec.metadata.id = "Package";
             _nuSpec.metadata.version = "1.0.0";
@@ -369,6 +380,13 @@ namespace ClrPlus.Scripting.MsBuild.Packaging {
                 pg = initTarget.AddPropertyGroup();
                 prop = pg.AddProperty("NugetMsBuildExtensionLoaded", "true");
                 prop.Condition = "'$(NugetMsBuildExtensionLoaded)' == '' OR '$(NuGet-OverlayLoaded)' == 'false'";
+
+                // ***************** VisionMap Custom Modification ***********************************
+                // Release the semaphore after executing all tasks in the AfterBuild step of the package.
+                // (see acquisition in the ctor)
+                var semaphore = Targets.Value.LookupTarget("AfterBuild").AddTask("ReleaseSemaphore");
+                semaphore.SetParameter("Handle", "$(SemaphoreHandle)");
+                // ***********************************************************************************
 
                 // then add the NuGetPackageOverlay tasks into the init target 
                 // var task = Targets.Value.LookupTarget("BeforeBuild").AddTask("CheckRuntimeLibrary");

--- a/clrplus/Scripting.MsBuild/Packaging/NugetPackage.cs
+++ b/clrplus/Scripting.MsBuild/Packaging/NugetPackage.cs
@@ -112,7 +112,6 @@ namespace ClrPlus.Scripting.MsBuild.Packaging {
             Props = new Lazy<ProjectPlus>(() => new ProjectPlus(this, "{0}.props".format(_pkgName)));
             Targets = new Lazy<ProjectPlus>(() => new ProjectPlus(this, "{0}.targets".format(_pkgName)));
 
-            // ***************** VisionMap Custom Modification ***********************************
             // Acquire semaphore because executing any tasks in the AfterBuild step of the package.
             // This prevents errors when multiple consumers of the package try to copy package
             // redistributables to the same destination. (see release in the Save method)
@@ -121,7 +120,6 @@ namespace ClrPlus.Scripting.MsBuild.Packaging {
                 semaphore.SetParameter("Name", "Sync_AfterBuild_" + _pkgName);
                 semaphore.AddOutputProperty("Handle", "SemaphoreHandle");
             }
-            // ***********************************************************************************
 
             _nuSpec.metadata.id = "Package";
             _nuSpec.metadata.version = "1.0.0";
@@ -381,12 +379,10 @@ namespace ClrPlus.Scripting.MsBuild.Packaging {
                 prop = pg.AddProperty("NugetMsBuildExtensionLoaded", "true");
                 prop.Condition = "'$(NugetMsBuildExtensionLoaded)' == '' OR '$(NuGet-OverlayLoaded)' == 'false'";
 
-                // ***************** VisionMap Custom Modification ***********************************
                 // Release the semaphore after executing all tasks in the AfterBuild step of the package.
                 // (see acquisition in the ctor)
                 var semaphore = Targets.Value.LookupTarget("AfterBuild").AddTask("ReleaseSemaphore");
                 semaphore.SetParameter("Handle", "$(SemaphoreHandle)");
-                // ***********************************************************************************
 
                 // then add the NuGetPackageOverlay tasks into the init target 
                 // var task = Targets.Value.LookupTarget("BeforeBuild").AddTask("CheckRuntimeLibrary");

--- a/clrplus/Scripting.MsBuild/Packaging/ProjectPlus.cs
+++ b/clrplus/Scripting.MsBuild/Packaging/ProjectPlus.cs
@@ -185,7 +185,6 @@ namespace ClrPlus.Scripting.MsBuild.Packaging {
 
         private IEnumerable<ToRoute> ImportGroupChildren {
             get {
-                // ********** Note: Implemented by VisionMap *************************
                 yield return "".MapTo<ProjectImportGroupElement>((parent, view) =>
                 {
                     return new ListWithAction<string>(s =>
@@ -194,7 +193,6 @@ namespace ClrPlus.Scripting.MsBuild.Packaging {
                         parent.AddImport(s);
                     });
                 });
-                // *******************************************************************
             }
         }
 

--- a/clrplus/Scripting.MsBuild/Packaging/ProjectPlus.cs
+++ b/clrplus/Scripting.MsBuild/Packaging/ProjectPlus.cs
@@ -185,7 +185,16 @@ namespace ClrPlus.Scripting.MsBuild.Packaging {
 
         private IEnumerable<ToRoute> ImportGroupChildren {
             get {
-                yield break;
+                // ********** Note: Implemented by VisionMap *************************
+                yield return "".MapTo<ProjectImportGroupElement>((parent, view) =>
+                {
+                    return new ListWithAction<string>(s =>
+                    {
+                        // when an item is added
+                        parent.AddImport(s);
+                    });
+                });
+                // *******************************************************************
             }
         }
 


### PR DESCRIPTION
External .props and .targets files can be included in the packages. (useful for many native packages such as Qt) Implements issue #37.
It also resolves two race conditions which can occur when building multiple projects referencing the same packages - overlay package installation is serialized (for each package separately), as well as the AfterBuild event (likewise)

The modifications are verified to work with Visual Studio 2015.