### PR TITLE
Fix names in EnumProperty element in propertiesui.xml files

### DIFF
--- a/clrplus/Scripting.MsBuild/Packaging/NugetPackage.cs
+++ b/clrplus/Scripting.MsBuild/Packaging/NugetPackage.cs
@@ -719,7 +719,7 @@ namespace ClrPlus.Scripting.MsBuild.Packaging {
 
                 // add the key
                 var enumProperty = xaml.Rule.Add("EnumProperty");
-                enumProperty.Attributes.Name = "{0}-{1}".format(pivot.Name, _pkgName);
+                enumProperty.Attributes.Name = "{0}-{1}".format(pivot.Name, SafeName);
                 enumProperty.Attributes.DisplayName = pivot.Name;
                 enumProperty.Attributes.Description = pivot.Description;
                 enumProperty.Attributes.Category = _pkgName;


### PR DESCRIPTION
This should fix the `Name` attribute value to have valid name without dots. Visual Studio 2015 complains about invalid property value if the name includes dot.

This triggers error in Visual Studio:
```
<EnumProperty Name="Linkage-grpc.dependencies.zlib">
```

Fixed name:
```
<EnumProperty Name="Linkage-grpc_dependencies_zlib">
```